### PR TITLE
fix indentation for yaml

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -7,10 +7,9 @@ spec:
   homepage: https://github.com/ahmetb/kubectl-foreach
   shortDescription: Run kubectl commands against some/all contexts in parallel
   description: |
-    Lets you run the same kubectl command against multiple contexts
-    simultaneously and prints their output, prefixed by context name.
-    You can choose or exclude contexts with exact name match or regular
-    expression patterns.
+    Run the same kubectl command against multiple contexts
+    simultaneously and print their output, prefixed by context name.
+    Choose contexts with exact name match or regular expressions.
   platforms:
   - selector:
       matchLabels:

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -12,33 +12,33 @@ spec:
     You can choose or exclude contexts with exact name match or regular
     expression patterns.
   platforms:
-    - selector:
-        matchLabels:
-          os: darwin
-          arch: amd64
-      {{addURIAndSha "https://github.com/ahmetb/kubectl-foreach/releases/download/{{ .TagName }}/kubectl-foreach_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
-      bin: kubectl-foreach
-    - selector:
-        matchLabels:
-          os: darwin
-          arch: arm64
-      {{addURIAndSha "https://github.com/ahmetb/kubectl-foreach/releases/download/{{ .TagName }}/kubectl-foreach_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
-      bin: kubectl-foreach
-    - selector:
-        matchLabels:
-          os: linux
-          arch: amd64
-      {{addURIAndSha "https://github.com/ahmetb/kubectl-foreach/releases/download/{{ .TagName }}/kubectl-foreach_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
-      bin: kubectl-foreach
-    - selector:
-        matchLabels:
-          os: linux
-          arch: arm64
-      {{addURIAndSha "https://github.com/ahmetb/kubectl-foreach/releases/download/{{ .TagName }}/kubectl-foreach_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
-      bin: kubectl-foreach
-    - selector:
-        matchLabels:
-          os: windows
-          arch: amd64
-      {{addURIAndSha "https://github.com/ahmetb/kubectl-foreach/releases/download/{{ .TagName }}/kubectl-foreach_{{ .TagName }}_windows_amd64.tar.gz" .TagName }}
-      bin: kubectl-foreach.exe
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/ahmetb/kubectl-foreach/releases/download/{{ .TagName }}/kubectl-foreach_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+    bin: kubectl-foreach
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/ahmetb/kubectl-foreach/releases/download/{{ .TagName }}/kubectl-foreach_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+    bin: kubectl-foreach
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/ahmetb/kubectl-foreach/releases/download/{{ .TagName }}/kubectl-foreach_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+    bin: kubectl-foreach
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/ahmetb/kubectl-foreach/releases/download/{{ .TagName }}/kubectl-foreach_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
+    bin: kubectl-foreach
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/ahmetb/kubectl-foreach/releases/download/{{ .TagName }}/kubectl-foreach_{{ .TagName }}_windows_amd64.tar.gz" .TagName }}
+    bin: kubectl-foreach.exe


### PR DESCRIPTION
Hi Ahmet,

thanks for reporting the issue. I looked at it and it seems like an indentation issue. 

if you notice `{{ addURIAndSha ...}}` in the original yaml is indented with 6 spaces. by default krew-release-bot indent with 4 spaces. 

if we indeed want 6 spaces, then we can use following:

```
{{addURIAndSha ...... | indent 6 }}
```

this was added for similar issue https://github.com/rajatjindal/krew-release-bot/issues/25 